### PR TITLE
Updating mailing list and source references to point to ASF

### DIFF
--- a/_includes/menu.md
+++ b/_includes/menu.md
@@ -2,4 +2,4 @@
 * [Documentation](/documentation/)
 * [Community](/documentation/community/)
 * [Development](/documentation/devguides/)
-* [Contact](http://groups.google.com/group/jclouds)
+* [Contact](http://incubator.apache.org/projects/jclouds.html)

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -46,13 +46,13 @@
 			<h1><a href="/documentation/reference/apps-that-use-jclouds/">Who uses jclouds?</a></h1>
 			<h1><a href="/documentation/devguides/">How can I help?</a></h1>
 		</div>
-                <div>
-                  <img src="http://incubator.apache.org/images/egg-logo.png"/>
-                </div>
+		<div>
+			<img src="http://incubator.apache.org/images/egg-logo.png"/>
+		</div>
 	</div>
 	<div id="menu" class="index_page">
 		<li><a href="https://twitter.com/jclouds">Twitter</a></li>
-		<li><a href="https://github.com/jclouds">GitHub</a></li>
+		<li><a href="https://github.com/jclouds">Source</a></li>
 		<li><a href="http://incubator.apache.org/projects/jclouds.html">Contact</a></li>
 	</div>
     <div id="footer">

--- a/documentation/community/index.md
+++ b/documentation/community/index.md
@@ -13,7 +13,7 @@ title: jclouds Community
 
 ## [Attend a jclouds event!](http://www.meetup.com/jclouds/events/calendar/)
 
-## [GitHub](https://github.com/jclouds/jclouds)
+## [Source](https://github.com/jclouds/jclouds)
 
 ## [Twitter](http://twitter.com/jclouds)
 

--- a/documentation/devguides/continuous-integration.markdown
+++ b/documentation/devguides/continuous-integration.markdown
@@ -9,8 +9,8 @@ title: jclouds Continuous Integration
 
 [CloudBees](http://www.cloudbees.com) is kindly supporting jclouds by providing free access to their hosted [DEV@cloud](http://www.cloudbees.com/dev.cb) continuous integration service. jclouds' [Jenkins image there](http://jclouds.ci.cloudbees.com) is set up to build all active jclouds branches under Java 6 and 7, as well as a number of other projects.
 
-From the main trunk build, snapshot artifacts are published to [Sonatype's OSS Nexus](https://oss.sonatype.org/) and are available from its [snapshot repository](https://oss.sonatype.org/content/repositories/snapshots/) (under [org/jclouds](https://oss.sonatype.org/content/repositories/snapshots/org/jclouds/)).
+From the main trunk build, snapshot artifacts are published to [Apache's Nexus](https://repository.apache.org/) and are available from its [snapshot repository](https://repository.apache.org/content/repositories/snapshots/) (under [org/apache/jclouds](https://repository.apache.org/content/repositories/snapshots/org/apache/jclouds/)).
 
 ## Jenkins
 
-If you think you might need access to jclouds' Jenkins, or would like a job set up there to build your jclouds-related project, please post a request to the [jclouds-dev mailing list](http://groups.google.com/group/jclouds-dev).
+If you think you might need access to jclouds' Jenkins, or would like a job set up there to build your jclouds-related project, please post a request to the jclouds [dev mailing list](http://incubator.apache.org/projects/jclouds.html).

--- a/documentation/devguides/contributing-to-jclouds.markdown
+++ b/documentation/devguides/contributing-to-jclouds.markdown
@@ -8,10 +8,14 @@ title: Contributing to the jclouds Code Base
 ## Introduction
 
 Welcome and thank you for your interest in contributing to jclouds!  This guide will take you through the process of making contributions to the jclouds 
-code base.  It will begin by walking you through how to commit changes to the jclouds repository on GitHub and then move on to more advanced development 
+code base.  It will begin by walking you through how to submit changes to the jclouds mirror repository on GitHub (the master copy of jclouds' source is hosted in [Apache's Git server](https://git-wip-us.apache.org/repos/asf?p=incubator-jclouds.git;a=summary))) and then move on to more advanced development 
 processes.
 
-If you are interested in helping us out with the jclouds documentation, please see our instructions for [contributing to jclouds documentation](http://www.jclouds.org/documentation/devguides/contributing-to-documentation/). 
+If you are interested in helping us out with the jclouds documentation, please see our instructions for [contributing to jclouds documentation](/documentation/devguides/contributing-to-documentation/). 
+
+## Opening a JIRA issue
+
+jclouds uses [Apache's JIRA](https://issues.apache.org/jira/browse/JCLOUDS) to keep track of bugs and feature request. Please check if your contribution is related to an existing issue, and otherwise create a new one describing the desired change.
 
 ## Working with jclouds on GitHub
 

--- a/documentation/devguides/index.md
+++ b/documentation/devguides/index.md
@@ -5,7 +5,7 @@ title: jclouds Developer Resources
 
 # jclouds Development Resources
 
-Code is hosted on [Git at the ASF](https://git-wip-us.apache.org/repos/asf?s=jclouds) but our process makes use of [github mirrors](https://github.com/jclouds).  
+Code is hosted on [Git at the ASF](https://git-wip-us.apache.org/repos/asf?s=jclouds) but our process makes use of [GitHub mirrors](https://github.com/jclouds).  
 
 ## Working on jclouds
 	
@@ -17,7 +17,7 @@ Code is hosted on [Git at the ASF](https://git-wip-us.apache.org/repos/asf?s=jcl
 
 ## References for Developers
 
-   *  [Github mirror](https://github.com/jclouds)
+   *  [GitHub mirror](https://github.com/jclouds)
    *  [Issue Tracker](https://issues.apache.org/jira/browse/JCLOUDS)
    *  [jclouds Continuous Integration](/documentation/devguides/continuous-integration)
    *  [Provider Metadata](/documentation/devguides/provider-metadata)

--- a/documentation/gettingstarted/index.md
+++ b/documentation/gettingstarted/index.md
@@ -17,7 +17,7 @@ title: Getting Started with jclouds
 
 * The user guide for the BlobStore abstraction
 
-## [Computeservice](/documentation/userguide/compute/)
+## [Compute](/documentation/userguide/compute/)
 
 * The user guide for the Computeservice abstraction
 

--- a/documentation/gettingstarted/what-is-jclouds.md
+++ b/documentation/gettingstarted/what-is-jclouds.md
@@ -19,7 +19,7 @@ jclouds offers several API abstractions as Java and Clojure libraries. The most 
 ## [BLOBSTORE](http://www.jclouds.org/documentation/userguide/blobstore-guide/)
 BlobStore is a simplified and portable means of managing your key-value storage providers.  BlobStore presents you with a straightforward 
 Map view of a container to access your data.
-
+
 ## [COMPUTESERVICE](http://www.jclouds.org/documentation/userguide/compute/)
 ComputeService streamlines the task of managing instances in the cloud by enabling you to start multiple machines at once and install software on them.
 

--- a/documentation/jcloudsguides/index.md
+++ b/documentation/jcloudsguides/index.md
@@ -7,7 +7,7 @@ title: jclouds User Guides
 
 ## jclouds APIs
 
-* [Computeservice API and Tools](/documentation/userguide/compute)
+* [Compute API and Tools](/documentation/userguide/compute)
 * [BlobStore API](/documentation/userguide/blobstore-guide)
 
 ## jclouds Basics to get Started


### PR DESCRIPTION
Addressing recent review comments about too many references to GitHub on the project site being a potential blocker for graduation.
