### PR TITLE
Fixed EC2 FAQ format

### DIFF
--- a/documentation/faqs/ec2-faq.md
+++ b/documentation/faqs/ec2-faq.md
@@ -1,6 +1,6 @@
 ---
 layout: jclouds
-title: Frequently Asked Questions: EC2 integration
+title: Frequently Asked Questions - EC2 integration
 ---
 
 # Frequently Asked Questions - Apache jclouds&reg; EC2 integration


### PR DESCRIPTION
Just noticed that the colon in the title was preventing the EC2 PAQ page to be properly generated. This changes fixes it!
