### PR TITLE
Unified mailing list links

### DIFF
--- a/documentation/reference/jclouds-logging.markdown
+++ b/documentation/reference/jclouds-logging.markdown
@@ -5,7 +5,7 @@ title: Logging
 
 ## Logging in Apache jclouds&reg;
 
-Logging in jclouds can save you time and effort when developing your code or looking for help. If your code is not behaving how you expect it to, enabling and configuring logging in jclouds can quickly give you valuable insight into the root cause of the issue. If you need help from the [jclouds-user mailing list](http://www.mail-archive.com/user@jclouds.apache.org/), the logs can help the people there assist you. The logs can be verbose so it's often best to simply copy and paste them into a [gist](https://gist.github.com/) and just post the link on the mailing list.
+Logging in jclouds can save you time and effort when developing your code or looking for help. If your code is not behaving how you expect it to, enabling and configuring logging in jclouds can quickly give you valuable insight into the root cause of the issue. If you need help from the [community](/documentation/community), the logs can help the people there assist you. The logs can be verbose so it's often best to simply copy and paste them into a [gist](https://gist.github.com/) and just post the link on the mailing list.
 
 By default, jclouds does no logging whatsoever for maximum performance.
 

--- a/documentation/userguide/bug-report.md
+++ b/documentation/userguide/bug-report.md
@@ -7,7 +7,7 @@ title: Documentation
 
 If you run into a bug while using jclouds, we encourage you to report it. To help you please collect as much of the following information as possible. If you can't get everything, that's okay. Send what you can.
 
-Bugs can be reported in [JIRA](https://issues.apache.org/jira/browse/JCLOUDS) or the [jclouds user mailing list](mailto:user@jclouds.apache.org) ([subscribe](mailto:jclouds-user-subscribe@apache.org)).
+Bugs can be reported in [JIRA](https://issues.apache.org/jira/browse/JCLOUDS) or the [jclouds user mailing list](/documentation/community).
 
 1. [jclouds Version](#jclouds-version)
 1. [Cloud and API Version](#cloud-version)


### PR DESCRIPTION
Addresses some of the comments @demobox made in https://github.com/jclouds/jclouds-site/pull/24 to unify the mailing list links and make all them point to the community page.
