### PR TITLE
Remove the GSoC announce from the frontpage

### DIFF
--- a/news/00-gsoc2014.md
+++ b/news/00-gsoc2014.md
@@ -3,7 +3,6 @@ layout: page
 title: Google Summer Of Code 2014
 permalink: /news/gsoc2014/
 label: GSOC 2014
-quicknew: Want to participate in Google Summer of Code 2014? See how you can join the program!
 ---
 
 -> [![Google Summer of Code 2014](/img/gsoc2014.png)](http://www.google-melange.com/gsoc/homepage/google/gsoc2014) <-


### PR DESCRIPTION
Remove the GSoC announce from the front page, as the registration period is closed.
