### PR TITLE
Specify version of HP Cloud Compute API

### DIFF
--- a/guides/hpcloud.md
+++ b/guides/hpcloud.md
@@ -67,6 +67,8 @@ context.close();
 ## HP Cloud Compute
 
 {% highlight java %}
+// If your account is using v13.5 of the HP Cloud Compute API
+// Please check [here](https://community.hpcloud.com/article/hp-public-cloud-quick-start-guide), and 
 // Set the API version for HP Cloud Compute in module overrides
 Properties properties = new Properties();
 properties.put("jclouds.api-version","2");


### PR DESCRIPTION
HP Cloud Compute is only available in the v2.0 version right now.
Without this change, users of this code snippet will get a NoSuchElementFoundException for the version v1.0
