### PR TITLE
Javadoc for 1.7.x

### DIFF
--- a/reference/javadoc/1.7.2/index.md
+++ b/reference/javadoc/1.7.2/index.md
@@ -1,6 +1,0 @@
----
-title: Javadoc for Apache jclouds 1.7.2
-permalink: /reference/javadoc/1.7.2/
----
-
-<iframe style="border: 0; width: 100%; height: 100%" src="http://aa89842ec0af95e12e87-532623b74dccdebb779ea274afab3f8f.r31.cf1.rackcdn.com/1.7.2/" frameborder="0"> </iframe>

--- a/reference/javadoc/index.md
+++ b/reference/javadoc/index.md
@@ -4,4 +4,4 @@ title: Javadoc for Apache jclouds
 permalink: /reference/javadoc/
 ---
 
-* [1.7.2](/reference/javadoc/1.7.2/)
+* [1.7.x](/reference/javadoc/1.7.x/)

--- a/releasenotes/1.7.2.md
+++ b/releasenotes/1.7.2.md
@@ -48,7 +48,7 @@ To get jclouds, please see the [jclouds installation guide](/start/install/).
 </dependencies>
 {% endhighlight %}
 
-* Here is the [Javadoc](/reference/javadoc/1.7.2/) for the new Swift and Cloud Files classes.
+* Here is the [Javadoc](/reference/javadoc/1.7.x/) for the new Swift and Cloud Files classes.
 
 ## <a id="issues"></a>Known Issues
 

--- a/releasenotes/1.7.3.md
+++ b/releasenotes/1.7.3.md
@@ -47,6 +47,8 @@ To get jclouds, please see the [jclouds installation guide](/start/install/).
 </dependencies>
 {% endhighlight %}
 
+* Here is the [Javadoc](/reference/javadoc/1.7.x/) for the new Swift and Cloud Files classes.
+
 ## <a id="issues"></a>Known Issues
 
 * jclouds 1.7.3 is incompatible with [Guava](https://code.google.com/p/guava-libraries/) 16 and 17. Please switch to Guava 15.0 or earlier, or wait for jclouds 1.8.

--- a/releasenotes/index.md
+++ b/releasenotes/index.md
@@ -6,10 +6,10 @@ permalink: /releasenotes/
 
 The Release Notes and Javadocs for every major release of Apache jclouds are listed chronologically below.
 
-* [1.7.3](/releasenotes/1.7.3) | TBD
-* [1.7.2](/releasenotes/1.7.2) | [Javadoc](/reference/javadoc/1.7.2/)
-* [1.7.1](/releasenotes/1.7.1) | [Javadoc](http://demobox.github.io/jclouds-maven-site-1.7.1/1.7.1/jclouds/apidocs/)
-* [1.7.0](/releasenotes/1.7.0) | [Javadoc](http://demobox.github.io/jclouds-maven-site-1.7.0/1.7.0/jclouds/apidocs/)
+* [1.7.3](/releasenotes/1.7.3) | [Javadoc](/reference/javadoc/1.7.x/)
+* [1.7.2](/releasenotes/1.7.2) | [Javadoc](/reference/javadoc/1.7.x/)
+* [1.7.1](/releasenotes/1.7.1) | [Javadoc](/reference/javadoc/1.7.x/)
+* [1.7.0](/releasenotes/1.7.0) | [Javadoc](/reference/javadoc/1.7.x/)
 * [1.6.3](/releasenotes/1.6.3) | [Javadoc](http://demobox.github.io/jclouds-maven-site-1.6.3/1.6.3/jclouds/apidocs/)
 * [1.6.2](/releasenotes/1.6.2) | [Javadoc](http://demobox.github.io/jclouds-maven-site-1.6.2/1.6.2-incubating/jclouds/apidocs/)
 * [1.6.1](/releasenotes/1.6.1) | [Javadoc](http://demobox.github.io/jclouds-maven-site-1.6.1/1.6.1-incubating/jclouds/apidocs/)


### PR DESCRIPTION
The links to /reference/javadoc/1.7.x/ won't actually work in the generated staging site because the Javadoc isn't in git, only svn.

You can see the Javadoc for 1.7.x right now at http://jclouds.apache.org/reference/javadoc/1.7.x/
