### PR TITLE
Force Jekyll 1.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository supports the GitHub Pages site for jclouds. See and read more at
 
 To deploy the site:
 
-* ensure you have [jekyll](http://jekyllrb.com/docs/installation/) 1.5.1 or newer installed
+* ensure you have [jekyll](http://jekyllrb.com/docs/installation/) 1.5.1 installed
 * if necessary, clone this repository
 * run `sh ./deploy-site.sh [$uid] [$pwd]` from the repository root. Here, `$uid` is your ASF account ID and `$pwd` your ASF password. If you do not supply your account ID or password, you will be prompted for them
 

--- a/deploy-site.sh
+++ b/deploy-site.sh
@@ -4,18 +4,19 @@
 #
 # Build the site using the default Jekyll version:
 # $ ./deploy-site.sh [username] [password]
-#
-# Build the site using a specific version of the Jekyll gem:
-# $ JEKYLL=1.5.1 ./deploy-site.sh [username] [password]
+
+JEKYLL_VERSION=1.5.1
+
+# Verify that the configured version of Jekyll is installed
+jekyll _${JEKYLL_VERSION}_ --version >/dev/null 2>&1
+if [[ $? -ne 0 ]]; then
+    echo "Jekyll ${JEKYLL_VERSION} is required"
+    exit 1
+fi
 
 set -o errexit
 
-JEKYLL_VERSION=`jekyll --version | awk '{print $2}'`
-JEKYLL_BUILD_VERSION=${JEKYLL:-$JEKYLL_VERSION}
-
-echo "Using Jekyll ${JEKYLL_BUILD_VERSION}..."
-jekyll _${JEKYLL_BUILD_VERSION}_ build --safe
-
+jekyll _${JEKYLL_VERSION}_ build --safe
 
 if [ ! -d "site-content" ]; then
   svn co https://svn.apache.org/repos/asf/jclouds/site-content


### PR DESCRIPTION
This commit forces Jekyll 1.5.1 to deploy the site. Different versions of Jekyll render the site with small differences, and that makes almost every commit to the SVN site repository contain many files that are unrelated to the change being committed.

To avoid this, we should make sure we all generate the site using the same version of Jekyll when deploying it. This commit forces version 1.5.1, which is the one used by the CI system to validate the pull requests,
