### PR TITLE
Fixed the deploy-site script

### DIFF
--- a/deploy-site.sh
+++ b/deploy-site.sh
@@ -24,13 +24,21 @@ else
   svn up site-content
 fi
 
-cp -r _site/* site-content/
-#jekyll copy site-content to _site so remove it
-rm -rf site-content/site-content
-rm site-content/deploy-site.sh
+rsync -ar --delete \
+    --exclude deploy-site.sh \
+    --exclude deploy-javadoc.sh \
+    --exclude site-content \
+    --filter='protect .svn/' \
+    --filter='protect reference/javadoc/**/*' \
+    --filter='protect jclouds-site.iml' \
+    _site/ site-content/
+
+cd site-content
+
+#delete removed files
+for f in `svn status | grep '^!' | awk '{print $NF}'`; do svn rm $f; done
 
 #add new files
-cd site-content
 svn status | awk '/^\?/{print $2}' | \
     while read filename; do svn --no-auto-props add $filename; done
 

--- a/reference/providers.md
+++ b/reference/providers.md
@@ -162,7 +162,7 @@ The Maven Group ID for all supported APIs below is [org.apache.jclouds.api](http
     </thead>
     <tbody>
         <tr>
-            <td><a href="/guides/abiquo/">Abiquo</a>*</td>
+            <td>Abiquo*</td>
             <td>abiquo</td>
         </tr>
         <tr>


### PR DESCRIPTION
The deploy script used the `cp` command so sync the generated files with the ones in SVN. That left all deleted files in the SVN, and some still were shown in the site. This changes the script to use rsync so all files that are no longer generated by Jekyll are also removed from SVN.

/cc @everett-toews 