### PR TITLE
Snapshot warning

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -56,6 +56,7 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">About Apache<strong class="caret"></strong></a>
                     <ul class="dropdown-menu">
                         <li><a href="http://www.apache.org">The Apache Software Foundation</a></li>
+                        <li><a href="http://www.apache.org/licenses/">License</a></li>
                         <li><a href="http://www.apache.org/foundation/contributing.html">Donations</a></li>
                         <li><a href="http://www.apache.org/foundation/sponsorship.html">Sponsorship</a></li>
                         <li><a href="http://www.apache.org/security/">Report a Vulnerability</a></li>

--- a/_posts/2016-08-22-arbitrary-cpu-ram.md
+++ b/_posts/2016-08-22-arbitrary-cpu-ram.md
@@ -5,6 +5,7 @@ date: 2016-08-22 07:00:00+00:00
 layout: post
 slug: arbitrary-cpu-ram
 title: Arbitrary CPU and RAM supported in the ComputeService
+quicknews: Read about our <strong>GSoC 2016 project</strong>! Support for arbitrary CPU and RAM has been added to the Compute abstraction
 ---
 
 As part of a [Google Summer of Code](https://developers.google.com/open-source/gsoc/) project has been added a feature to allow users to set manually specific values of CPU and RAM.

--- a/start/install.md
+++ b/start/install.md
@@ -44,7 +44,7 @@ If you do not have a *pom.xml* file, you can copy and paste the one below. If yo
 ### Using the daily builds
 
 <div class="alert alert-danger">
-<strong>Warning!</strong> These are snapshot builds; untested builds provided for your convenience. They have not been tested, and are not official releases of the Apache jclouds project or the Apache Software Foundation.
+<strong>Warning!</strong> These are untested snapshot builds provided for convenience; they are not official releases of the Apache jclouds project, or the Apache Software Foundation.
 </div>
 
 If you want to use the bleeding edge release of jclouds, you'll need to setup a maven dependency pointing to our snapshot repository. You need to update your repositories and add the following in your project's pom.xml:
@@ -93,7 +93,7 @@ You can add jclouds to your *project.clj* like below, supporting clojure 1.2 and
 ### Using the daily builds
 
 <div class="alert alert-danger">
-<strong>Warning!</strong> These are snapshot builds; untested builds provided for your convenience. They have not been tested, and are not official releases of the Apache jclouds project or the Apache Software Foundation.
+<strong>Warning!</strong> These are untested snapshot builds provided for convenience; they are not official releases of the Apache jclouds project, or the Apache Software Foundation.
 </div>
 
 You can add jclouds snapshots to your *project.clj* like below:
@@ -136,7 +136,7 @@ Then, add jclouds to your *build.xml* as shown below:
 ### Using the daily builds
 
 <div class="alert alert-danger">
-<strong>Warning!</strong> These are snapshot builds; untested builds provided for your convenience. They have not been tested, and are not official releases of the Apache jclouds project or the Apache Software Foundation.
+<strong>Warning!</strong> These are untested snapshot builds provided for convenience; they are not official releases of the Apache jclouds project, or the Apache Software Foundation.
 </div>
 
 You will need to install [maven ant tasks](http://maven.apache.org/ant-tasks/index.html). Then, add jclouds snapshot dependencies to your *build.xml* as shown below:

--- a/start/install.md
+++ b/start/install.md
@@ -43,6 +43,10 @@ If you do not have a *pom.xml* file, you can copy and paste the one below. If yo
 
 ### Using the daily builds
 
+<div class="alert alert-danger">
+<strong>Warning!</strong> These are snapshot builds; untested builds provided for your convenience. They have not been tested, and are not official releases of the Apache jclouds project or the Apache Software Foundation.
+</div>
+
 If you want to use the bleeding edge release of jclouds, you'll need to setup a maven dependency pointing to our snapshot repository. You need to update your repositories and add the following in your project's pom.xml:
 
 {% highlight xml %}
@@ -88,6 +92,10 @@ You can add jclouds to your *project.clj* like below, supporting clojure 1.2 and
 
 ### Using the daily builds
 
+<div class="alert alert-danger">
+<strong>Warning!</strong> These are snapshot builds; untested builds provided for your convenience. They have not been tested, and are not official releases of the Apache jclouds project or the Apache Software Foundation.
+</div>
+
 You can add jclouds snapshots to your *project.clj* like below:
 
 {% highlight clojure %}
@@ -126,6 +134,10 @@ Then, add jclouds to your *build.xml* as shown below:
 {% endhighlight %}
 
 ### Using the daily builds
+
+<div class="alert alert-danger">
+<strong>Warning!</strong> These are snapshot builds; untested builds provided for your convenience. They have not been tested, and are not official releases of the Apache jclouds project or the Apache Software Foundation.
+</div>
 
 You will need to install [maven ant tasks](http://maven.apache.org/ant-tasks/index.html). Then, add jclouds snapshot dependencies to your *build.xml* as shown below:
 


### PR DESCRIPTION
Added reference to the GSoC post in the landing page, and warnings to the snapshot downloads according to the ASF policy for distribution of unreleased material.