### PR TITLE
Promote ApacheCon

### DIFF
--- a/_includes/apachecon.html
+++ b/_includes/apachecon.html
@@ -1,0 +1,12 @@
+<div id="apachecon" class="alert alert-success">
+    <p>
+        <a href="http://www.apache.org/events/current-event.html">
+            <img style="float: left; margin-right: 10px;" src="http://www.apache.org/events/current-event-234x60.png"/>
+        </a>
+        <strong>ApacheCon North America</strong> is coming to Miami!<br/>
+        ApacheCon is the premier community event of the Apache Software Foundation.
+        It's the best place to meet the other people in your community, learn about Apache software projects, and hack on ASF code.
+        See the <a href="http://www.apache.org/events/current-event.html">main conference site</a> for details and registration.
+    </p>
+    <div style="clear: both;"></div>
+</div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -36,6 +36,8 @@
                 </div>
             </div>
 
+            {% include apachecon.html %}
+
             <div id="releasenews" class="alert alert-info">
                 <p>The <a href="/start/install/">latest version</a> is {{ site.latest_version }} released on {{ site.latest_version_date }}! Read the <a href="/releasenotes/{{ site.latest_version }}/">release notes</a>.</p>
             </div>


### PR DESCRIPTION
The linked site and images are automatically updated for every event, so it should be OK to include the ApacheCon fragment as-is whenever the conference is approaching, and just change the location text when needed.