### PR TITLE
Blog post about linking Nova and Neutron

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 This repository supports the GitHub Pages site for jclouds. See and read more at [http://www.jclouds.org](http://www.jclouds.org).
 
+To test the site locally:
+
+    jekyll _1.5.1_ serve --safe
+
 To deploy the site:
 
-* ensure you have [jekyll](http://jekyllrb.com/docs/installation/) 1.5.1 installed
-* if necessary, clone this repository
-* run `sh ./deploy-site.sh [$uid] [$pwd]` from the repository root. Here, `$uid` is your ASF account ID and `$pwd` your ASF password. If you do not supply your account ID or password, you will be prompted for them
+* Ensure you have [jekyll](http://jekyllrb.com/docs/installation/) 1.5.1 installed
+* If necessary, clone this repository
+* Run `sh ./deploy-site.sh [$uid] [$pwd]` from the repository root. Here, `$uid` is your ASF account ID and `$pwd` your ASF password. If you do not supply your account ID or password, you will be prompted for them
 

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -40,7 +40,7 @@
             </div>
 
             <div id="keystonev3" class="alert alert-success">
-                <p>If you are an OpenStack user, read our blog posts about the <a href="/blog/2018/01/16/keystone-v3/">OpenStack Keystone V3</a> and <a href="/blog/2018/02/06/nova-neutron">OpenStack Nova and Neutron</a> integrations that will be released in jclouds <strong>2.1.0</strong>!</p>
+                <p>Read our blog posts about the <a href="/blog/2018/01/16/keystone-v3/">OpenStack Keystone V3</a> and <a href="/blog/2018/02/06/nova-neutron">Context linking & Neutron support for Nova</a> integrations released in jclouds <strong>2.1.0</strong>!</p>
             </div>
 
             <div id="releasenews" class="alert alert-info">

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -40,7 +40,7 @@
             </div>
 
             <div id="keystonev3" class="alert alert-success">
-                <p>If you are an OpenStack user, read our <a href="/blog/2018/01/16/keystone-v3/">last blog post</a> about the <strong>OpenStack Keystone V3</strong> integration that will be released in jclouds <strong>2.1.0</strong>!</p>
+                <p>If you are an OpenStack user, read our blog posts about the <a href="/blog/2018/01/16/keystone-v3/">OpenStack Keystone V3</a> and <a href="/blog/2018/02/06/nova-neutron">OpenStack Nova and Neutron</a> integrations that will be released in jclouds <strong>2.1.0</strong>!</p>
             </div>
 
             <div id="releasenews" class="alert alert-info">

--- a/_posts/2018-02-06-nova-neutron.md
+++ b/_posts/2018-02-06-nova-neutron.md
@@ -4,19 +4,24 @@ comments: true
 date: 2018-02-06 07:00:00+00:00
 layout: post
 slug: nova-neutron
-title: OpenStack Nova and Neutron
+title: Introducing context linking & Neutron support for Nova
 ---
 
-One of the limitations of the jclouds implementation of the OpenStack Nova API is that is was not able to directly talk to the Neutron service. It used legacy security group APIs to manage access to instances, and there was no proper support for custom networking.
+One of the limitations of some jclouds APIs and Providers is that they are isolated libraries that cannot directly interact between them. There are scenarios where this would be desirable, such as letting OpenStack Nova (compute) use the OpenStack Neutron API (networking) to perform all networking related operations. There was no direct way to implement this in the jclouds APIs code, and users were left with the responsibility of invoking both APIs to have the desired behavior.
 
-Starting from Apache jclouds 2.1.0, an integration with OpenStack Neutron will be provided and users will be able to configure their Nova APIs to interact with a custom Neutron deployment.
+Apache jclouds 2.1.0 comes with a **context linking** feature, where APIs and providers that have dependencies between them can be *linked* so they can call each other where needed.
+
 <!-- more -->
 
-To achieve this, users will be able to use the recent **context linking** feature, where APIs and providers that have dependencies between them can be *linked* so they can call each other where needed.
+## Context Linking
+
+Linking one API or Provider to another is something that has to be defined in the API or Provider itself. It is a mechanism that allows users to inject an API or Provider *inside* a given jclouds context, so the API that *receives* the linked context can use it internally. Linking is not supposed to be used to link arbitrary APIs and Providers (that would have no effect), but APIs that are *prepared* to receive linked contexts and call its API methods.
+
+For example, in jclouds 2.1.0, OpenStack Nova has been integrated with Neutron, and users will be able to link the `openstack-nova` context to an `openstack-neutron` one so the Nova API can use the Neutron features to manage all networking stuff. On the other hand, linking other APIs or providers together may have no effect, as the code for those APIs and providers may not expect any linked context. When thinking about linking two contexts together, please refer to the docs.
+
+Linking is done at *context* level, and links are specified in the *using* context and point to the context(s) that it uses. This isolates each individual context and allows users to configure an independent set of properties for each one without overlapping issues. The `ContextLinking.linkContext` and `ContextLinking.linkView` helper methods can be used to easily link one context or view to another.
 
 ## Linking OpenStack Nova to Neutron
-
-Links between APIs and providers are done at *context* level. This isolates each individual context and allows users to configure an independent set of properties for each one without overlapping issues. The `ContextLinking.linkContext` and `ContextLinking.linkView` helper methods can be used to easily link one context or view to another.
 
 The following example shows how to link an OpenStack Nova API to a Neutron API context, to leverage Neutron features when provisioning instances with Nova:
 

--- a/_posts/2018-02-06-nova-neutron.md
+++ b/_posts/2018-02-06-nova-neutron.md
@@ -1,0 +1,43 @@
+---
+author: <a href="https://twitter.com/IgnasiBarrera">Ignasi Barrera</a>
+comments: true
+date: 2018-02-06 07:00:00+00:00
+layout: post
+slug: nova-neutron
+title: OpenStack Nova and Neutron
+---
+
+One of the limitations of the jclouds implementation of the OpenStack Nova API is that is was not able to directly talk to the Neutron service. It used legacy security group APIs to manage access to instances, and there was no proper support for custom networking.
+
+Starting from Apache jclouds 2.1.0, an integration with OpenStack Neutron will be provided and users will be able to configure their Nova APIs to interact with a custom Neutron deployment.
+<!-- more -->
+
+To achieve this, users will be able to use the recent **context linking** feature, where APIs and providers that have dependencies between them can be *linked* so they can call each other where needed.
+
+## Linking OpenStack Nova to Neutron
+
+Links between APIs and providers are done at *context* level. This isolates each individual context and allows users to configure an independent set of properties for each one without overlapping issues. The `ContextLinking.linkContext` and `ContextLinking.linkView` helper methods can be used to easily link one context or view to another.
+
+The following example shows how to link an OpenStack Nova API to a Neutron API context, to leverage Neutron features when provisioning instances with Nova:
+
+{% highlight java %}
+// Create the connection to OpenStack Neutron
+ApiContext<NeutronApi> neutronCtx = ContextBuilder.newBuilder("openstack-neutron")
+   .endpoint("http://localhost/identity/v3/")
+   .credentials("domain:user", "password")
+   .overrides(neutronProperties)
+   .modules(ImmutableSet.of(new SLF4JLoggingModule()))
+   .build();
+
+// Create the connection to OpenStack nova and link it to Neutron
+NovaApi nova = ContextBuilder.newBuilder("openstack-nova")
+   .endpoint("http://localhost/identity/v3/")
+   .credentials("domain:user", "password")
+   .overrides(novaProperties)
+   .modules(ImmutableSet.of(
+               ContextLinking.linkContext(neutronCtx),
+               new SLF4JLoggingModule()))
+   .buildApi(NovaApi.class);
+{% endhighlight %}
+
+With this configuration the `nova` API is configured to use the linked `neutron` for all networking operations.


### PR DESCRIPTION
The blog post describes the context linking feature that is used starting from 2.1.0 to allow OpenStack Nova APIs use a given Neutron deployment for networking operations.
This blog should be linked from the 2.1.0 release notes.